### PR TITLE
Enabled ARC in the podspec file

### DIFF
--- a/DropBlocks.podspec
+++ b/DropBlocks.podspec
@@ -8,5 +8,6 @@ Pod::Spec.new do |s|
   s.author       = { 'Nate Petersen' => 'nate@digitalrickshaw.com' }
   s.source       = { :git => 'https://github.com/natep/DropBlocks.git', :tag => '0.0.3' }
   s.source_files = 'DropBlocks/Classes'
+  s.requires_arc = true
   s.dependency     'Dropbox-iOS-SDK'
 end


### PR DESCRIPTION
When I analyze my XCode project which uses DropBlocks, I get potential memory leaks in DropBlocks.m. I think the reason is that ARC is not enabled in podspec (the DropBlocks project itself is ARC enabled).
